### PR TITLE
✨ feat: API 명세서 기반으로 Post, Comment API 구조 설계

### DIFF
--- a/src/main/java/com/project/teama_be/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/project/teama_be/domain/chat/entity/ChatMessage.java
@@ -27,4 +27,11 @@ public class ChatMessage extends BaseEntity {
 
     @Column(name = "content", nullable = false)
     private String content;
+
+    // 클라이언트에서 사용할 고유 ID (UUID)
+    @Column(name = "message_id", unique = true, nullable = false)
+    private String messageId;
+
+    @Column(name = "parent_message_id")
+    private String parentMessageId;  // 답장 대상 메시지 ID (null이면 일반 메시지)
 }

--- a/src/main/java/com/project/teama_be/domain/post/controller/CommentController.java
+++ b/src/main/java/com/project/teama_be/domain/post/controller/CommentController.java
@@ -1,0 +1,126 @@
+package com.project.teama_be.domain.post.controller;
+
+import com.project.teama_be.domain.post.dto.request.CommentReqDTO;
+import com.project.teama_be.domain.post.dto.response.CommentResDTO;
+import com.project.teama_be.global.apiPayload.CustomResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+@Tag(name = "댓글 API")
+public class CommentController {
+
+    // GET 요청
+    // 댓글 목록 조회
+    @GetMapping("/posts/{postId}/comments")
+    @Operation(
+            summary = "댓글 목록 조회",
+            description = "게시글에 작성된 모든 댓글을 조회합니다. " +
+                    "커서 기반 페이지네이션, 최신 순으로 정렬합니다."
+    )
+    public CustomResponse<CommentResDTO.PageableComment<CommentResDTO.Comment>> getComments(
+            @PathVariable Long postId,
+            @RequestParam(defaultValue = "-1") Long cursor,
+            @RequestParam(defaultValue = "1") Long size
+    ) {
+        return CustomResponse.onSuccess(null);
+    }
+
+    // 대댓글 목록 조회
+    @GetMapping("/comments/{commentId}/reply")
+    @Operation(
+            summary = "대댓글 목록 조회",
+            description = "댓글의 댓글 (대댓글)을 조회합니다. " +
+                    "커서 기반 페이지네이션, 오래된 순으로 정렬합니다."
+    )
+    public CustomResponse<CommentResDTO.PageableComment<CommentResDTO.Reply>> getReplies(
+            @PathVariable Long commentId,
+            @RequestParam(defaultValue = "-1") Long cursor,
+            @RequestParam(defaultValue = "1") Long size
+    ) {
+        return CustomResponse.onSuccess(null);
+    }
+
+    // 내가 작성한 댓글 조회
+    @GetMapping("/members/{memberId}/comments")
+    @Operation(
+            summary = "내가 작성한 댓글 조회",
+            description = "내가 작성한 모든 댓글을 조회합니다. " +
+                    "커서 기반 페이지네이션, 최신 순으로 정렬합니다."
+    )
+    public CustomResponse<CommentResDTO.PageableComment<CommentResDTO.SimpleComment>> getMyComments(
+            @PathVariable Long memberId,
+            @RequestParam(defaultValue = "-1") Long cursor,
+            @RequestParam(defaultValue = "1") Long size
+    ) {
+        return CustomResponse.onSuccess(null);
+    }
+
+    // POST 요청
+    // 댓글 달기
+    @PostMapping("/posts/{postId}/comments")
+    @Operation(
+            summary = "댓글 작성",
+            description = "댓글을 작성합니다."
+    )
+    public CustomResponse<CommentResDTO.CommentUpload> uploadComment(
+            @PathVariable Long postId,
+            @RequestBody CommentReqDTO.Commenting commentContent
+    ) {
+        return CustomResponse.onSuccess(null);
+    }
+
+    // 대댓글 작성
+    @PostMapping("/comments/{commentId}/replies")
+    @Operation(
+            summary = "대댓글 작성",
+            description = "대댓글을 작성합니다."
+    )
+    public CustomResponse<CommentResDTO.CommentUpload> uploadReply(
+            @PathVariable Long commentId,
+            @RequestBody CommentReqDTO.Commenting commentContent
+    ) {
+        return CustomResponse.onSuccess(null);
+    }
+
+    // 댓글 좋아요
+    @PostMapping("/comments/{commentId}/like")
+    @Operation(
+            summary = "댓글 좋아요",
+            description = "댓글에 좋아요를 표시합니다."
+    )
+    public CustomResponse<CommentResDTO.CommentLike> likeComment(
+            @PathVariable Long commentId
+    ) {
+        return CustomResponse.onSuccess(null);
+    }
+
+    // 댓글 수정 (미정 기능)
+    @PatchMapping("/comments/{commentId}")
+    @Operation(
+            summary = "댓글 수정 (미정 기능)",
+            description = "댓글을 수정합니다."
+    )
+    public CustomResponse<CommentResDTO.CommentUpdate> commentUpdate(
+            @PathVariable Long commentId,
+            @RequestBody CommentReqDTO.CommentUpdate commentContent
+    ) {
+        return CustomResponse.onSuccess(null);
+    }
+
+    // 댓글 삭제 (미정 기능)
+    @DeleteMapping("/comments/{commentId}")
+    @Operation(
+            summary = "댓글 삭제 (미정 기능)",
+            description = "댓글을 삭제합니다. (Soft Delete)"
+    )
+    public CustomResponse<CommentResDTO.CommentDelete> deleteComment(
+            @PathVariable Long commentId
+    ) {
+        return CustomResponse.onSuccess(null);
+    }
+}

--- a/src/main/java/com/project/teama_be/domain/post/controller/PostController.java
+++ b/src/main/java/com/project/teama_be/domain/post/controller/PostController.java
@@ -5,7 +5,6 @@ import com.project.teama_be.domain.post.dto.request.PostReqDTO;
 import com.project.teama_be.domain.post.dto.response.PostResDTO;
 import com.project.teama_be.global.apiPayload.CustomResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;

--- a/src/main/java/com/project/teama_be/domain/post/controller/PostController.java
+++ b/src/main/java/com/project/teama_be/domain/post/controller/PostController.java
@@ -24,7 +24,7 @@ public class PostController {
     // 가게명으로 게시글 조회
     @GetMapping("/places/posts")
     @Operation(
-            summary = "가게명으로 게시글 조회 API",
+            summary = "가게명으로 게시글 조회",
             description = "해당 가게의 게시글 중 최근 게시된 게시글을 조회합니다." +
                     "Query Parameter를 중복하여 사용함으로써 홈화면(지도 화면)에 표시할 게시글을 조회할 수 있습니다." +
                     "커서 기반 페이지네이션, 최신 순으로 정렬합니다."
@@ -91,7 +91,7 @@ public class PostController {
             description = "마이페이지에서 최근 본 게시글을 조회합니다. " +
                     "커서 기반 페이지네이션, 최신 순으로 정렬합니다."
     )
-    public CustomResponse<PostResDTO.PageablePost<PostResDTO.SimplePost>> getRecentViewPosts(
+    public CustomResponse<PostResDTO.PageablePost<PostResDTO.RecentPost>> getRecentViewPosts(
             @PathVariable Long memberId,
             @RequestParam(defaultValue = "-1") Long cursor,
             @RequestParam(defaultValue = "1") Long size

--- a/src/main/java/com/project/teama_be/domain/post/controller/PostController.java
+++ b/src/main/java/com/project/teama_be/domain/post/controller/PostController.java
@@ -1,0 +1,175 @@
+package com.project.teama_be.domain.post.controller;
+
+
+import com.project.teama_be.domain.post.dto.request.PostReqDTO;
+import com.project.teama_be.domain.post.dto.response.PostResDTO;
+import com.project.teama_be.global.apiPayload.CustomResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+@Tag(name = "게시글 API")
+public class PostController {
+
+    // GET 요청
+    // 가게명으로 게시글 조회
+    @GetMapping("/places/posts")
+    @Operation(
+            summary = "가게명으로 게시글 조회 API",
+            description = "해당 가게의 게시글 중 최근 게시된 게시글을 조회합니다." +
+                    "Query Parameter를 중복하여 사용함으로써 홈화면(지도 화면)에 표시할 게시글을 조회할 수 있습니다." +
+                    "커서 기반 페이지네이션, 최신 순으로 정렬합니다."
+    )
+    public CustomResponse<PostResDTO.PageablePost<PostResDTO.SimplePost>> getPostsByPlaceName(
+            @RequestParam List<String> query,
+            @RequestParam(defaultValue = "-1") String cursor,
+            @RequestParam(defaultValue = "1") Long size
+    ) {
+        return CustomResponse.onSuccess(null);
+    }
+
+    // 키워드 검색
+    @GetMapping("/posts")
+    @Operation(
+            summary = "키워드 검색",
+            description = "키워드를 통해 게시글을 조회합니다. " +
+                    "키워드 종류를 선택해야 합니다. (태그, 장소명) " +
+                    "커서 기반 페이지네이션, 최신 순으로 정렬합니다."
+    )
+    public CustomResponse<PostResDTO.PageablePost<PostResDTO.FullPost>> getPostsByKeyword(
+            @RequestParam String query,
+            @RequestParam String type,
+            @RequestParam(defaultValue = "-1") Long cursor,
+            @RequestParam(defaultValue = "1") Long size
+    ) {
+        return CustomResponse.onSuccess(null);
+    }
+
+    // 가게 게시글 모두 조회
+    @GetMapping("/places/{placeId}/posts")
+    @Operation(
+            summary = "가게 게시글 모두 조회",
+            description = "해당 가게의 모든 게시글을 조회합니다. " +
+                    "커서 기반 페이지네이션, 최신 순으로 정렬합니다."
+    )
+    public CustomResponse<PostResDTO.PageablePost<PostResDTO.FullPost>> getAllPostsAboutPlace(
+            @PathVariable Long placeId,
+            @RequestParam(defaultValue = "-1") Long cursor,
+            @RequestParam(defaultValue = "1") Long size
+    ) {
+        return CustomResponse.onSuccess(null);
+    }
+
+    // 내가 작성한 게시글 조회 (마이페이지)
+    @GetMapping("/members/{memberId}/posts")
+    @Operation(
+            summary = "내가 작성한 게시글 조회 (마이페이지)",
+            description = "마이페이지에서 내가 올렸던 게시글을 조회합니다. " +
+                    "커서 기반 페이지네이션, 최신 순으로 정렬합니다."
+    )
+    public CustomResponse<PostResDTO.PageablePost<PostResDTO.SimplePost>> getAllPostsByMemberId(
+            @PathVariable Long memberId,
+            @RequestParam(defaultValue = "-1") Long cursor,
+            @RequestParam(defaultValue = "1") Long size
+    ) {
+        return CustomResponse.onSuccess(null);
+    }
+
+    // 최근 본 게시글 조회
+    @GetMapping("/members/{memberId}/posts/recent")
+    @Operation(
+            summary = "최근 본 게시글 조회",
+            description = "마이페이지에서 최근 본 게시글을 조회합니다. " +
+                    "커서 기반 페이지네이션, 최신 순으로 정렬합니다."
+    )
+    public CustomResponse<PostResDTO.PageablePost<PostResDTO.SimplePost>> getRecentPostsByMemberId(
+            @PathVariable Long memberId,
+            @RequestParam(defaultValue = "-1") Long cursor,
+            @RequestParam(defaultValue = "1") Long size
+    ) {
+        return CustomResponse.onSuccess(null);
+    }
+
+    // 내가 좋아요 누른 게시글 조회
+    @GetMapping("/members/{memberId}/posts/like")
+    @Operation(
+            summary = "내가 좋아요 누른 게시글 조회",
+            description = "마이페이지에서 좋아요를 누른 게시글을 조회합니다. " +
+                    "커서 기반 페이지네이션, 최신 순으로 정렬합니다."
+    )
+    public CustomResponse<PostResDTO.PageablePost<PostResDTO.SimplePost>> getLikePostsByMemberId(
+            @PathVariable Long memberId,
+            @RequestParam(defaultValue = "-1") Long cursor,
+            @RequestParam(defaultValue = "1") Long size
+    ) {
+        return CustomResponse.onSuccess(null);
+    }
+
+    // POST 요청
+    // 게시글 업로드 (파일은 multipart/form-data, 게시글 관련 데이터는 application/json)
+    @PostMapping(
+            value = "/posts",
+            consumes = {
+                MediaType.MULTIPART_FORM_DATA_VALUE
+            }
+    )
+    @Operation(
+            summary = "게시글 업로드",
+            description = "게시글을 업로드합니다. " +
+                    "반드시 RequestBody를 multipart/form-data로 전송해 주세요."
+    )
+    public CustomResponse<PostResDTO.PostUpload> uploadPost(
+            @RequestPart List<MultipartFile> image,
+            @RequestBody PostReqDTO.postUpload postContent
+    ) {
+        return CustomResponse.onSuccess(null);
+    }
+
+    // 게시글 좋아요
+    @PostMapping("/posts/{postId}/like")
+    @Operation(
+            summary = "게시글 좋아요",
+            description = "게시글에 좋아요를 반영합니다."
+    )
+    public CustomResponse<PostResDTO.PostLike> likePost(
+            @PathVariable Long postId
+    ) {
+        return CustomResponse.onSuccess(null);
+    }
+
+    // PATCH 요청
+    // 게시글 수정 (미정 기능)
+    @PatchMapping("/posts/{postId}")
+    @Operation(
+            summary = "게시글 수정 (미정 기능)",
+            description = "게시글을 수정합니다."
+    )
+    public CustomResponse<PostResDTO.PostUpdate> updatePost(
+            @PathVariable Long postId,
+            @RequestBody(required = false) PostReqDTO.postUpdate postContent
+    ) {
+        return CustomResponse.onSuccess(null);
+    }
+
+    // DELETE 요청 (SoftDelete 적용해야 함)
+    // 게시글 삭제 (미정 기능)
+    @DeleteMapping("/posts/{postId}")
+    @Operation(
+            summary = "게시글 삭제 (미정 기능)",
+            description = "게시글을 삭제합니다 (SoftDelete)"
+    )
+    public CustomResponse<PostResDTO.PostDelete> deletePost(
+            @PathVariable Long postId
+    ) {
+        return CustomResponse.onSuccess(null);
+    }
+}

--- a/src/main/java/com/project/teama_be/domain/post/controller/PostController.java
+++ b/src/main/java/com/project/teama_be/domain/post/controller/PostController.java
@@ -76,7 +76,7 @@ public class PostController {
             description = "마이페이지에서 내가 올렸던 게시글을 조회합니다. " +
                     "커서 기반 페이지네이션, 최신 순으로 정렬합니다."
     )
-    public CustomResponse<PostResDTO.PageablePost<PostResDTO.SimplePost>> getAllPostsByMemberId(
+    public CustomResponse<PostResDTO.PageablePost<PostResDTO.SimplePost>> getMyPosts(
             @PathVariable Long memberId,
             @RequestParam(defaultValue = "-1") Long cursor,
             @RequestParam(defaultValue = "1") Long size
@@ -91,7 +91,7 @@ public class PostController {
             description = "마이페이지에서 최근 본 게시글을 조회합니다. " +
                     "커서 기반 페이지네이션, 최신 순으로 정렬합니다."
     )
-    public CustomResponse<PostResDTO.PageablePost<PostResDTO.SimplePost>> getRecentPostsByMemberId(
+    public CustomResponse<PostResDTO.PageablePost<PostResDTO.SimplePost>> getRecentViewPosts(
             @PathVariable Long memberId,
             @RequestParam(defaultValue = "-1") Long cursor,
             @RequestParam(defaultValue = "1") Long size
@@ -106,7 +106,7 @@ public class PostController {
             description = "마이페이지에서 좋아요를 누른 게시글을 조회합니다. " +
                     "커서 기반 페이지네이션, 최신 순으로 정렬합니다."
     )
-    public CustomResponse<PostResDTO.PageablePost<PostResDTO.SimplePost>> getLikePostsByMemberId(
+    public CustomResponse<PostResDTO.PageablePost<PostResDTO.SimplePost>> getLikedPosts(
             @PathVariable Long memberId,
             @RequestParam(defaultValue = "-1") Long cursor,
             @RequestParam(defaultValue = "1") Long size

--- a/src/main/java/com/project/teama_be/domain/post/converter/CommentConverter.java
+++ b/src/main/java/com/project/teama_be/domain/post/converter/CommentConverter.java
@@ -1,0 +1,4 @@
+package com.project.teama_be.domain.post.converter;
+
+public class CommentConverter {
+}

--- a/src/main/java/com/project/teama_be/domain/post/converter/PostConverter.java
+++ b/src/main/java/com/project/teama_be/domain/post/converter/PostConverter.java
@@ -1,0 +1,4 @@
+package com.project.teama_be.domain.post.converter;
+
+public class PostConverter {
+}

--- a/src/main/java/com/project/teama_be/domain/post/dto/request/CommentReqDTO.java
+++ b/src/main/java/com/project/teama_be/domain/post/dto/request/CommentReqDTO.java
@@ -1,0 +1,12 @@
+package com.project.teama_be.domain.post.dto.request;
+
+public class CommentReqDTO {
+
+    public record Commenting(
+            String content
+    ) {}
+
+    public record CommentUpdate(
+            String content
+    ) {}
+}

--- a/src/main/java/com/project/teama_be/domain/post/dto/request/PostReqDTO.java
+++ b/src/main/java/com/project/teama_be/domain/post/dto/request/PostReqDTO.java
@@ -1,0 +1,25 @@
+package com.project.teama_be.domain.post.dto.request;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public class PostReqDTO {
+
+    // 게사글 업로드 (위치정보, 태그, 내용, 비공개 여부)
+    public record postUpload(
+            BigDecimal latitude,
+            BigDecimal longitude,
+            String placeName,
+            List<String> tags,
+            String content,
+            Boolean isPrivate
+    ) {}
+
+    // 게시글 수정
+    public record postUpdate(
+            Long memberId,
+            String content,
+            List<String> tags,
+            Long placeId
+    ) {}
+}

--- a/src/main/java/com/project/teama_be/domain/post/dto/request/PostReqDTO.java
+++ b/src/main/java/com/project/teama_be/domain/post/dto/request/PostReqDTO.java
@@ -17,7 +17,6 @@ public class PostReqDTO {
 
     // 게시글 수정
     public record postUpdate(
-            Long memberId,
             String content,
             List<String> tags,
             Long placeId

--- a/src/main/java/com/project/teama_be/domain/post/dto/response/CommentResDTO.java
+++ b/src/main/java/com/project/teama_be/domain/post/dto/response/CommentResDTO.java
@@ -1,0 +1,68 @@
+package com.project.teama_be.domain.post.dto.response;
+
+import com.project.teama_be.domain.post.enums.ReactionType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class CommentResDTO {
+
+    // 댓글
+    public record Comment(
+            Long commentId,
+            String nickname,
+            String profileUrl,
+            String content,
+            Long likeCount,
+            Long replyCount
+    ) {}
+
+    // 대댓글
+    public record Reply(
+            Long commentId,
+            String nickname,
+            String profileUrl,
+            String content,
+            Long likeCount
+    ) {}
+
+    // 간략화 한 댓글
+    public record SimpleComment(
+            Long commentId,
+            String content,
+            Long likeCount
+    ) {}
+
+    // 커서 기반 페이지네이션 (댓글은 최신 순, 대댓글은 오래된 순)
+    public record PageableComment<T>(
+            List<T> comment,
+            Boolean hasNext,
+            Long pageSize,
+            Long cursor
+    ) {}
+
+    // 댓글 작성
+    public record CommentUpload(
+            Long commentId,
+            LocalDateTime createdAt
+    ) {}
+
+    // 댓글 좋아요
+    public record CommentLike(
+            Long commentId,
+            ReactionType reactionType,
+            LocalDateTime updatedAt
+    ) {}
+
+    // 댓글 수정
+    public record CommentUpdate(
+            Long commentId,
+            LocalDateTime updatedAt
+    ) {}
+
+    // 댓글 삭제
+    public record CommentDelete(
+            Long commentId,
+            LocalDateTime deletedAt
+    ) {}
+}

--- a/src/main/java/com/project/teama_be/domain/post/dto/response/PostResDTO.java
+++ b/src/main/java/com/project/teama_be/domain/post/dto/response/PostResDTO.java
@@ -1,0 +1,76 @@
+package com.project.teama_be.domain.post.dto.response;
+
+import com.project.teama_be.domain.post.enums.ReactionType;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class PostResDTO {
+
+    // 전체 게시글
+    @Builder
+    public record FullPost(
+            String nickname,
+            String profileUrl,
+            List<String> postImageUrl,
+            Long imageTotalCount,
+            Long postId,
+            Long placeId,
+            Long likeCount,
+            Long commentCount,
+            String placeName,
+            String content,
+            List<String> tags
+    ) {}
+
+    // 간소화된 게시글 (이미지만 보이는 경우)
+    @Builder
+    public record SimplePost(
+            String postImageUrl,
+            Long postId,
+            String placeName,
+            Long placeId
+    ) {}
+
+    // 커서 기반 페이지네이션 틀
+    @Builder
+    public record PageablePost<T>(
+            List<T> post,
+            Boolean hasNext,
+            Long pageSize,
+            Long cursor
+    ) {}
+
+    // 게시글 업로드 완료
+    @Builder
+    public record PostUpload(
+            Long postId,
+            Long placeId,
+            LocalDateTime createdAt
+    ) {}
+
+    // 게시글 좋아요 완료
+    @Builder
+    public record PostLike(
+            Long postId,
+            ReactionType reactionType,
+            LocalDateTime updatedAt
+    ) {}
+
+    // 게시글 수정 완료
+    @Builder
+    public record PostUpdate(
+            Long postId,
+            Long placeId,
+            LocalDateTime updatedAt
+    ) {}
+
+    // 게시글 삭제 완료
+    @Builder
+    public record PostDelete(
+            Long postId,
+            LocalDateTime deletedAt
+    ) {}
+}

--- a/src/main/java/com/project/teama_be/domain/post/dto/response/PostResDTO.java
+++ b/src/main/java/com/project/teama_be/domain/post/dto/response/PostResDTO.java
@@ -3,7 +3,6 @@ package com.project.teama_be.domain.post.dto.response;
 import com.project.teama_be.domain.post.enums.ReactionType;
 import lombok.Builder;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -32,6 +31,16 @@ public class PostResDTO {
             Long postId,
             String placeName,
             Long placeId
+    ) {}
+
+    // 최근 본 게시글
+    @Builder
+    public record RecentPost(
+            String PostImageUrl,
+            Long PostId,
+            String placeName,
+            Long placeId,
+            LocalDateTime viewedAt
     ) {}
 
     // 커서 기반 페이지네이션 틀

--- a/src/main/java/com/project/teama_be/domain/post/entity/Comment.java
+++ b/src/main/java/com/project/teama_be/domain/post/entity/Comment.java
@@ -30,4 +30,7 @@ public class Comment extends BaseEntity {
 
     @Column(name = "like_count")
     private Integer likeCount;
+
+    @Column(name = "parent_id")
+    private Long parentId;
 }

--- a/src/main/java/com/project/teama_be/domain/post/entity/PostReaction.java
+++ b/src/main/java/com/project/teama_be/domain/post/entity/PostReaction.java
@@ -1,6 +1,7 @@
 package com.project.teama_be.domain.post.entity;
 
 import com.project.teama_be.domain.member.entity.Member;
+import com.project.teama_be.domain.post.enums.ReactionType;
 import com.project.teama_be.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -26,5 +27,6 @@ public class PostReaction extends BaseEntity {
     private Member member;
 
     @Column(name = "reaction_type", nullable = false)
-    private String reactionType; // 'LIKE' 또는 'UNLIKE'
+    @Enumerated(EnumType.STRING)
+    private ReactionType reactionType;
 }

--- a/src/main/java/com/project/teama_be/domain/post/enums/ReactionType.java
+++ b/src/main/java/com/project/teama_be/domain/post/enums/ReactionType.java
@@ -1,0 +1,5 @@
+package com.project.teama_be.domain.post.enums;
+
+public enum ReactionType {
+    LIKE, UNLIKE
+}


### PR DESCRIPTION
# ☝️Issue Number

- #9 

##  📌 개요

- API 명세서 기반으로 Post, Comment API 구조만 설계
- Request, Response 만 정의

## 🔁 변경 사항

- Post API 구조 설계 : 120e288178aa405adf63542edec6a75447236153
- Comment API 구조 설계 : 2beb6d203a87d43661ff65ea1247b12159a3517b

### ♻️ 리팩토링

- Post ReactionType, String -> Enum 변경 : aa87b26c080cf46b5ec351d46d1c0365e59b9834
- Post API 메서드 이름 변경 : 9a414a45bce36ca31bc13e9602ebacdeba29457b
- API 명세서와 불일치하는 속성 변경, DTO에 필요 없는 속성 제거 : 3ac2b680c418880d2959647c8484df8ae5bbf212
- import문 최적화 : 94f2370da57b92fa20f289558a041572a477a6e3

## 📸 스크린샷
- Swagger 현황
![스크린샷 2025-05-04 21 36 52](https://github.com/user-attachments/assets/7a59a159-f24c-479b-a84e-0d44ceb9c2d3)

## 👀 기타 더 이야기해볼 점