### PR TITLE
✨feat: Auth API 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,15 @@ dependencies {
     annotationProcessor "io.github.openfeign.querydsl:querydsl-apt:6.1:jpa"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+
+    // WebClient
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    // Netty
+    implementation 'io.netty:netty-resolver-dns-native-macos:4.1.68.Final:osx-aarch_64'
+
+    // OAuth2 login
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 }
 
 jar{

--- a/src/main/java/com/project/teama_be/domain/member/controller/AuthController.java
+++ b/src/main/java/com/project/teama_be/domain/member/controller/AuthController.java
@@ -2,17 +2,12 @@ package com.project.teama_be.domain.member.controller;
 
 import com.project.teama_be.domain.member.dto.request.MemberReqDTO;
 import com.project.teama_be.domain.member.dto.response.MemberResDTO;
+import com.project.teama_be.domain.member.service.AuthCommandService;
 import com.project.teama_be.domain.member.service.JwtTokenService;
 import com.project.teama_be.global.apiPayload.CustomResponse;
-import com.project.teama_be.global.apiPayload.exception.CustomException;
-import com.project.teama_be.global.security.annotation.CurrentUser;
 import com.project.teama_be.global.security.dto.JwtDTO;
-import com.project.teama_be.global.security.userdetails.AuthUser;
-import com.project.teama_be.global.security.util.JwtUtil;
-import com.project.teama_be.global.utils.HttpResponseUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -31,13 +26,14 @@ import java.io.IOException;
 public class AuthController {
 
     private final JwtTokenService jwtTokenService;
+    private final AuthCommandService authCommandService;
 
     @PostMapping(value = "/signup", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @Operation(summary = "회원가입 API by 김지명 (개발중)", description = "사용자 정보와 프로필 이미지를 함께 받아 회원가입을 처리합니다.")
+    @Operation(summary = "회원가입 API by 김지명", description = "사용자 정보와 프로필 이미지를 함께 받아 회원가입을 처리합니다.")
     public CustomResponse<MemberResDTO.SignUp> signUp(@RequestPart("SignUp") @Valid MemberReqDTO.SignUp reqDTO,
                                                       @RequestPart("profileImage") MultipartFile profileImage) {
-
-        return CustomResponse.onSuccess(null);
+        MemberResDTO.SignUp resDTO = authCommandService.signUp(reqDTO, profileImage);
+        return CustomResponse.onSuccess(HttpStatus.CREATED, resDTO);
     }
 
     // Swagger용 컨트롤러

--- a/src/main/java/com/project/teama_be/domain/member/controller/AuthController.java
+++ b/src/main/java/com/project/teama_be/domain/member/controller/AuthController.java
@@ -6,8 +6,10 @@ import com.project.teama_be.domain.member.service.AuthCommandService;
 import com.project.teama_be.domain.member.service.JwtTokenService;
 import com.project.teama_be.global.apiPayload.CustomResponse;
 import com.project.teama_be.global.security.dto.JwtDTO;
+import com.project.teama_be.global.security.util.JwtUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -22,14 +24,14 @@ import java.io.IOException;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/auth")
 @Tag(name = "인증 관련 API", description = "인증 관련 API입니다.")
 public class AuthController {
 
     private final JwtTokenService jwtTokenService;
     private final AuthCommandService authCommandService;
+    private final JwtUtil jwtUtil;
 
-    @PostMapping(value = "/signup", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(value = "/api/auth/signup", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "회원가입 API by 김지명", description = "사용자 정보와 프로필 이미지를 함께 받아 회원가입을 처리합니다.")
     public CustomResponse<MemberResDTO.SignUp> signUp(@RequestPart("SignUp") @Valid MemberReqDTO.SignUp reqDTO,
                                                       @RequestPart("profileImage") MultipartFile profileImage) {
@@ -38,18 +40,18 @@ public class AuthController {
     }
 
     // Swagger용 컨트롤러
-    @PostMapping("/login")
+    @PostMapping("/api/auth/login")
     @Operation(summary = "로그인 API by 김지명", description = "아이디와 비밀번호를 검증하고 JWT 토큰을 발급합니다.")
     public CustomResponse<JwtDTO> login(@RequestBody @Valid MemberReqDTO.Login reqDTO) {
         return CustomResponse.onSuccess(null);
     }
 
     // Swagger용 컨트롤러
-    @PostMapping("/logout")
+    @PostMapping("/api/auth/logout")
     @Operation(summary = "로그아웃 API by 김지명", description = "현재 로그인된 사용자의 토큰을 무효화하고 로그아웃 처리합니다.")
     public CustomResponse<String> logout() {return CustomResponse.onSuccess("로그아웃이 완료되었습니다.");}
 
-    @PostMapping("/refresh")
+    @PostMapping("/api/auth/refresh")
     @Operation(summary = "JWT 재발급 API", description = "쿠키에 담긴 RefreshToken을 검증하고 새 JWT를 발급합니다.")
     public void refreshToken(
             @CookieValue(value = "refresh_token", required = false) String refreshToken,
@@ -58,5 +60,32 @@ public class AuthController {
         jwtTokenService.reissueTokenAndSetCookie(refreshToken, response);
     }
 
+    @GetMapping("/oauth2/callback/kakao")
+    @Operation(summary = "카카오 로그인 API", description = "인가코드를 넘겨받으면 사용자의 정보를 리소스 서버에서 가져와 JWT 토큰을 발급")
+    public CustomResponse<JwtDTO> loginWithKakao(@RequestParam("code") String code, HttpServletResponse response) {
+        log.info("카카오 로그인 콜백 요청 - 인증 코드: {}", code);
+        JwtDTO jwtDTO = authCommandService.loginWithKakao(code);
+        setCookies(response, jwtDTO.accessToken(), jwtDTO.refreshToken());
 
+        return CustomResponse.onSuccess(jwtDTO);
+    }
+
+    private void setCookies(HttpServletResponse response, String accessToken, String refreshToken) {
+        // 액세스 토큰 쿠키
+        Cookie accessCookie = new Cookie("access_token", accessToken);
+        accessCookie.setHttpOnly(true);
+        accessCookie.setPath("/");
+        accessCookie.setMaxAge(Math.toIntExact(jwtUtil.getAccessExpMs() / 1000));
+        accessCookie.setSecure(true); // HTTPS에서만 전송
+
+        // 리프레시 토큰 쿠키
+        Cookie refreshCookie = new Cookie("refresh_token", refreshToken);
+        refreshCookie.setHttpOnly(true);
+        refreshCookie.setPath("/");
+        refreshCookie.setMaxAge(Math.toIntExact(jwtUtil.getRefreshExpMs() / 1000));
+        refreshCookie.setSecure(true); // HTTPS에서만 전송
+
+        response.addCookie(accessCookie);
+        response.addCookie(refreshCookie);
+    }
 }

--- a/src/main/java/com/project/teama_be/domain/member/controller/AuthController.java
+++ b/src/main/java/com/project/teama_be/domain/member/controller/AuthController.java
@@ -12,6 +12,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -45,7 +46,7 @@ public class AuthController {
 
     // Swagger용 컨트롤러
     @PostMapping("/logout")
-    @Operation(summary = "로그아웃 API by 김지명 (개발중)", description = "현재 로그인된 사용자의 토큰을 무효화하고 로그아웃 처리합니다.")
+    @Operation(summary = "로그아웃 API by 김지명", description = "현재 로그인된 사용자의 토큰을 무효화하고 로그아웃 처리합니다.")
     public CustomResponse<String> logout() {return CustomResponse.onSuccess("로그아웃이 완료되었습니다.");}
 
     @PostMapping("/refresh")

--- a/src/main/java/com/project/teama_be/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/project/teama_be/domain/member/converter/MemberConverter.java
@@ -1,0 +1,36 @@
+package com.project.teama_be.domain.member.converter;
+
+import com.project.teama_be.domain.member.dto.request.MemberReqDTO;
+import com.project.teama_be.domain.member.dto.response.MemberResDTO;
+import com.project.teama_be.domain.member.entity.Member;
+import com.project.teama_be.domain.member.enums.LoginType;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberConverter {
+
+    // SignUpReqDTO -> Member Entity
+    public static Member toMember(MemberReqDTO.SignUp reqDTO, PasswordEncoder passwordEncoder, String profileImageUrl) {
+        return Member.builder()
+                .loginId(reqDTO.loginId())
+                .nickname(reqDTO.nickname())
+                .password(passwordEncoder.encode(reqDTO.password()))
+                .location(null)
+                .isAgree(true)
+                .loginType(LoginType.LOCAL)
+                .profileUrl(profileImageUrl)
+                .build();
+    }
+
+    public static MemberResDTO.SignUp toSignUpResDTO(Member member) {
+        return MemberResDTO.SignUp.builder()
+                .memberId(member.getId())
+                .loginId(member.getLoginId())
+                .nickname(member.getNickname())
+                .profileImageUrl(member.getProfileUrl())
+                .createdAt(member.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/project/teama_be/domain/member/dto/response/MemberResDTO.java
+++ b/src/main/java/com/project/teama_be/domain/member/dto/response/MemberResDTO.java
@@ -1,13 +1,17 @@
 package com.project.teama_be.domain.member.dto.response;
 
+import lombok.Builder;
+
 import java.time.LocalDateTime;
 
 public class MemberResDTO {
 
+    @Builder
     public record SignUp(
             Long memberId,
             String loginId,
             String nickname,
+            String profileImageUrl,
             LocalDateTime createdAt
     ) {
     }

--- a/src/main/java/com/project/teama_be/domain/member/dto/response/OAuth2DTO.java
+++ b/src/main/java/com/project/teama_be/domain/member/dto/response/OAuth2DTO.java
@@ -1,0 +1,46 @@
+package com.project.teama_be.domain.member.dto.response;
+
+public class OAuth2DTO {
+
+    public record OAuth2TokenDTO(
+            String token_type,
+            String access_token,
+            String refresh_token,
+            Long expires_in,
+            Long refresh_token_expires_in,
+            String scope
+    ) {}
+
+    public record KakaoProfile(
+            Long id,
+            String connected_at,
+            Properties properties,
+            KakaoAccount kakao_account
+    ) {
+        public record Properties(
+                String nickname,
+                String profile_image,
+                String thumbnail_image
+        ) {}
+
+        public record KakaoAccount(
+                String email,
+                Boolean is_email_verified,
+                Boolean email_needs_agreement,
+                Boolean has_email,
+                Boolean profile_nickname_needs_agreement,
+                Boolean profile_image_needs_agreement,
+                Boolean email_needs_argument,
+                Boolean is_email_valid,
+                Profile profile
+        ) {
+            public record Profile(
+                    String nickname,
+                    String thumbnail_image_url,
+                    String profile_image_url,
+                    Boolean is_default_nickname,
+                    Boolean is_default_image
+            ) {}
+        }
+    }
+}

--- a/src/main/java/com/project/teama_be/domain/member/entity/Member.java
+++ b/src/main/java/com/project/teama_be/domain/member/entity/Member.java
@@ -18,12 +18,15 @@ public class Member extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "location_id")
+    @ManyToOne(fetch = FetchType.LAZY, optional = true)
+    @JoinColumn(name = "location_id", nullable = true)
     private Location location;
 
     @Column(name = "login_id")
     private String loginId;
+
+    @Column(name = "email")
+    private String email;
 
     @Column(name = "password")
     private String password;

--- a/src/main/java/com/project/teama_be/domain/member/exceptioin/MemberErrorCode.java
+++ b/src/main/java/com/project/teama_be/domain/member/exceptioin/MemberErrorCode.java
@@ -9,12 +9,13 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum MemberErrorCode implements BaseErrorCode {
 
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE404_0", "해당 사용자를 찾을 수 없습니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404_0", "해당 사용자를 찾을 수 없습니다."),
     OAUTH_USER_INFO_FAIL(HttpStatus.NOT_FOUND, "MEMBER404_2", "사용자 정보 조회 실패"),
     OAUTH_TOKEN_FAIL(HttpStatus.BAD_REQUEST, "MEMBER400_1", "토큰 변환 실패"),
     OAUTH_EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER400_2", "이메일 정보를 찾을 수 없습니다."),
     LOGIN_ID_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "MEMBER400_3", "해당 LoginID가 이미 존재합니다."),
     NICKNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "MEMBER400_4", "해당 Nickname이 이미 존재합니다."),
+    PROFILE_IMAGE_UPLOAD_FAILED(HttpStatus.BAD_REQUEST, "MEMBER400_5", "프로필 사진 업로드 실패"),
     OAUTH_LOGIN_FAIL(HttpStatus.UNAUTHORIZED, "MEMBER401_1", "로그인에 실패하였습니다."),
     ;
 

--- a/src/main/java/com/project/teama_be/domain/member/exceptioin/MemberErrorCode.java
+++ b/src/main/java/com/project/teama_be/domain/member/exceptioin/MemberErrorCode.java
@@ -1,0 +1,24 @@
+package com.project.teama_be.domain.member.exceptioin;
+
+import com.project.teama_be.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MemberErrorCode implements BaseErrorCode {
+
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE404_0", "해당 사용자를 찾을 수 없습니다."),
+    OAUTH_USER_INFO_FAIL(HttpStatus.NOT_FOUND, "MEMBER404_2", "사용자 정보 조회 실패"),
+    OAUTH_TOKEN_FAIL(HttpStatus.BAD_REQUEST, "MEMBER400_1", "토큰 변환 실패"),
+    OAUTH_EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER400_2", "이메일 정보를 찾을 수 없습니다."),
+    LOGIN_ID_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "MEMBER400_3", "해당 LoginID가 이미 존재합니다."),
+    NICKNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "MEMBER400_4", "해당 Nickname이 이미 존재합니다."),
+    OAUTH_LOGIN_FAIL(HttpStatus.UNAUTHORIZED, "MEMBER401_1", "로그인에 실패하였습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/project/teama_be/domain/member/exceptioin/MemberException.java
+++ b/src/main/java/com/project/teama_be/domain/member/exceptioin/MemberException.java
@@ -1,0 +1,12 @@
+package com.project.teama_be.domain.member.exceptioin;
+
+import com.project.teama_be.global.apiPayload.exception.CustomException;
+import lombok.Getter;
+
+@Getter
+public class MemberException extends CustomException {
+
+    public MemberException(MemberErrorCode errorCode){
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/project/teama_be/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/project/teama_be/domain/member/repository/MemberRepository.java
@@ -10,4 +10,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByLoginId(String loginId);
     boolean existsByLoginId(String loginId);
     boolean existsByNickname(String nickname);
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/project/teama_be/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/project/teama_be/domain/member/repository/MemberRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByLoginId(String loginId);
+    boolean existsByLoginId(String loginId);
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/project/teama_be/domain/member/service/AuthCommandService.java
+++ b/src/main/java/com/project/teama_be/domain/member/service/AuthCommandService.java
@@ -1,0 +1,41 @@
+package com.project.teama_be.domain.member.service;
+
+import com.project.teama_be.domain.member.converter.MemberConverter;
+import com.project.teama_be.domain.member.dto.request.MemberReqDTO;
+import com.project.teama_be.domain.member.dto.response.MemberResDTO;
+import com.project.teama_be.domain.member.entity.Member;
+import com.project.teama_be.domain.member.exceptioin.MemberErrorCode;
+import com.project.teama_be.domain.member.exceptioin.MemberException;
+import com.project.teama_be.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AuthCommandService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public MemberResDTO.SignUp signUp(MemberReqDTO.SignUp reqDTO, MultipartFile profileImage) {
+        if (memberRepository.existsByLoginId(reqDTO.loginId())) {
+            throw new MemberException(MemberErrorCode.LOGIN_ID_ALREADY_EXISTS);
+        }
+
+        if (memberRepository.existsByNickname(reqDTO.nickname())) {
+            throw new MemberException(MemberErrorCode.NICKNAME_ALREADY_EXISTS);
+        }
+
+        // 프로필 이미지 S3 업로드 Util 메서드 사용
+        String profileImageUrl = null;
+
+        Member member = MemberConverter.toMember(reqDTO, passwordEncoder, profileImageUrl);
+        memberRepository.save(member);
+
+        return MemberConverter.toSignUpResDTO(member);
+    }
+}

--- a/src/main/java/com/project/teama_be/domain/member/service/AuthCommandService.java
+++ b/src/main/java/com/project/teama_be/domain/member/service/AuthCommandService.java
@@ -3,17 +3,33 @@ package com.project.teama_be.domain.member.service;
 import com.project.teama_be.domain.member.converter.MemberConverter;
 import com.project.teama_be.domain.member.dto.request.MemberReqDTO;
 import com.project.teama_be.domain.member.dto.response.MemberResDTO;
+import com.project.teama_be.domain.member.dto.response.OAuth2DTO;
 import com.project.teama_be.domain.member.entity.Member;
+import com.project.teama_be.domain.member.enums.LoginType;
 import com.project.teama_be.domain.member.exceptioin.MemberErrorCode;
 import com.project.teama_be.domain.member.exceptioin.MemberException;
 import com.project.teama_be.domain.member.repository.MemberRepository;
 import com.project.teama_be.global.aws.util.S3Util;
+import com.project.teama_be.global.security.dto.JwtDTO;
+import com.project.teama_be.global.security.userdetails.CustomUserDetails;
+import com.project.teama_be.global.security.util.JwtUtil;
+import com.project.teama_be.global.utils.HttpResponseUtil;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
 @Slf4j
 @Service
@@ -25,6 +41,23 @@ public class AuthCommandService {
     private final PasswordEncoder passwordEncoder;
     private final S3Util s3Util;
     private static final String PROFILE_IMAGE_FOLDER = "profiles/";
+    private final WebClient webClient = WebClient.builder().build();
+    private final JwtUtil jwtUtil;
+
+    @Value("${spring.security.oauth2.client.provider.kakao.token-uri}")
+    private String tokenURI;
+
+    @Value("${spring.security.oauth2.client.provider.kakao.user-info-uri}")
+    private String userInfoURI;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
+    private String redirectURI;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
+    private String clientSecret;
 
     public MemberResDTO.SignUp signUp(MemberReqDTO.SignUp reqDTO, MultipartFile profileImage) {
         if (memberRepository.existsByLoginId(reqDTO.loginId())) {
@@ -49,7 +82,7 @@ public class AuthCommandService {
             }
         } else {
             log.info("[ 회원가입 ] 프로필 이미지 없음, 기본 이미지 사용");
-            // 기본 프로필 이미지 URL 설정
+            // Todo: 기본 프로필 이미지 URL 설정
             // profileImageUrl = "https://your-bucket.s3.region.amazonaws.com/profiles/default.png";
         }
 
@@ -57,5 +90,108 @@ public class AuthCommandService {
         memberRepository.save(member);
 
         return MemberConverter.toSignUpResDTO(member);
+    }
+
+    public JwtDTO loginWithKakao(String code) {
+        try {
+            // 1. Access Token 요청
+            log.info("Access Token 요청 중...");
+            OAuth2DTO.OAuth2TokenDTO tokenDto = getAccessToken(code);
+
+            // 2. 사용자 정보 요청
+            log.info("사용자 정보 요청 중...");
+            OAuth2DTO.KakaoProfile kakaoProfile = getUserInfo(tokenDto.access_token());
+
+            // 3. 이메일 확인
+            String email = kakaoProfile.kakao_account().email();
+            log.info("이메일 확인: {}", email);
+            if (email == null) {
+                throw new MemberException(MemberErrorCode.OAUTH_EMAIL_NOT_FOUND);
+            }
+
+            // 4. 데이터베이스에서 사용자 조회 또는 신규 사용자 저장
+            log.info("사용자 조회 또는 저장 중...");
+            Member member = memberRepository.findByEmail(email)
+                    .orElseGet(() -> memberRepository.save(
+                            Member.builder()
+                                    .email(email)
+                                    .nickname("임시닉네임_" + System.currentTimeMillis())
+                                    .loginType(LoginType.KAKAO)
+                                    .isAgree(true)
+                                    // Todo: 기본 이미지로 설정하기
+                                    //.profileUrl()
+                                    .build()));
+
+            CustomUserDetails customUserDetails = new CustomUserDetails(member);
+
+            // 5. JWT 토큰 발급
+            log.info("JWT 토큰 발급 중...");
+            String accessToken = jwtUtil.createJwtAccessToken(customUserDetails);
+            String refreshToken = jwtUtil.createJwtRefreshToken(customUserDetails);
+
+            // JwtDTO 반환
+            return JwtDTO.builder()
+                    .accessToken(accessToken)
+                    .refreshToken(refreshToken)
+                    .build();
+
+        } catch (Exception e) {
+            log.error("카카오 로그인 실패: {}", e.getMessage(), e);
+            throw new MemberException(MemberErrorCode.OAUTH_LOGIN_FAIL);
+        }
+    }
+
+    private OAuth2DTO.OAuth2TokenDTO getAccessToken(String code) {
+        try {
+            MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+            formData.add("grant_type", "authorization_code");
+            formData.add("client_id", clientId);
+            formData.add("redirect_uri", redirectURI);
+            formData.add("code", code);
+            formData.add("client_secret", clientSecret);
+
+            System.out.println("=== AccessToken 요청 정보 ===");
+            System.out.println("토큰 URI: " + tokenURI);
+            System.out.println("클라이언트 ID: " + clientId);
+            System.out.println("리다이렉트 URI: " + redirectURI);
+            System.out.println("인증 코드: " + code);
+
+            return webClient.post()
+                    .uri(tokenURI)
+                    .header(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded")
+                    .bodyValue(formData)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::isError, response -> {
+                        System.err.println("토큰 요청 오류: " + response.statusCode());
+                        return response.bodyToMono(String.class)
+                                .flatMap(errorBody -> {
+                                    System.err.println("오류 응답: " + errorBody);
+                                    return Mono.error(new RuntimeException("토큰 요청 실패: " + errorBody));
+                                });
+                    })
+                    .bodyToMono(OAuth2DTO.OAuth2TokenDTO.class)
+                    .doOnSuccess(token -> System.out.println("토큰 발급 성공: " + token.access_token()))
+                    .doOnError(e -> {
+                        System.err.println("토큰 요청 오류: " + e.getMessage());
+                        e.printStackTrace();
+                    })
+                    .onErrorMap(e -> new MemberException(MemberErrorCode.OAUTH_TOKEN_FAIL))
+                    .block();
+        } catch (Exception e) {
+            System.err.println("예외 발생: " + e.getMessage());
+            e.printStackTrace();
+            throw new MemberException(MemberErrorCode.OAUTH_TOKEN_FAIL);
+        }
+    }
+
+    private OAuth2DTO.KakaoProfile getUserInfo(String accessToken) {
+        return webClient.get()
+                .uri(userInfoURI)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .header(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded;charset=utf-8")
+                .retrieve()
+                .bodyToMono(OAuth2DTO.KakaoProfile.class)
+                .onErrorMap(e -> new MemberException(MemberErrorCode.OAUTH_USER_INFO_FAIL)) // 에러 처리
+                .block();
     }
 }

--- a/src/main/java/com/project/teama_be/domain/member/service/AuthCommandService.java
+++ b/src/main/java/com/project/teama_be/domain/member/service/AuthCommandService.java
@@ -40,9 +40,10 @@ public class AuthCommandService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final S3Util s3Util;
-    private static final String PROFILE_IMAGE_FOLDER = "profiles/";
     private final WebClient webClient = WebClient.builder().build();
     private final JwtUtil jwtUtil;
+    private static final String PROFILE_IMAGE_FOLDER = "user-image/";
+    private static final String DEFAULT_PROFILE_IMAGE_URI = "https://s3.ap-northeast-2.amazonaws.com/api-smp.shop/user-image/TempUser.png";
 
     @Value("${spring.security.oauth2.client.provider.kakao.token-uri}")
     private String tokenURI;
@@ -82,8 +83,7 @@ public class AuthCommandService {
             }
         } else {
             log.info("[ 회원가입 ] 프로필 이미지 없음, 기본 이미지 사용");
-            // Todo: 기본 프로필 이미지 URL 설정
-            // profileImageUrl = "https://your-bucket.s3.region.amazonaws.com/profiles/default.png";
+            profileImageUrl = DEFAULT_PROFILE_IMAGE_URI;
         }
 
         Member member = MemberConverter.toMember(reqDTO, passwordEncoder, profileImageUrl);
@@ -118,8 +118,7 @@ public class AuthCommandService {
                                     .nickname("임시닉네임_" + System.currentTimeMillis())
                                     .loginType(LoginType.KAKAO)
                                     .isAgree(true)
-                                    // Todo: 기본 이미지로 설정하기
-                                    //.profileUrl()
+                                    .profileUrl(DEFAULT_PROFILE_IMAGE_URI)
                                     .build()));
 
             CustomUserDetails customUserDetails = new CustomUserDetails(member);

--- a/src/main/java/com/project/teama_be/domain/member/service/AuthCommandService.java
+++ b/src/main/java/com/project/teama_be/domain/member/service/AuthCommandService.java
@@ -7,12 +7,15 @@ import com.project.teama_be.domain.member.entity.Member;
 import com.project.teama_be.domain.member.exceptioin.MemberErrorCode;
 import com.project.teama_be.domain.member.exceptioin.MemberException;
 import com.project.teama_be.domain.member.repository.MemberRepository;
+import com.project.teama_be.global.aws.util.S3Util;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -20,6 +23,8 @@ public class AuthCommandService {
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
+    private final S3Util s3Util;
+    private static final String PROFILE_IMAGE_FOLDER = "profiles/";
 
     public MemberResDTO.SignUp signUp(MemberReqDTO.SignUp reqDTO, MultipartFile profileImage) {
         if (memberRepository.existsByLoginId(reqDTO.loginId())) {
@@ -32,6 +37,21 @@ public class AuthCommandService {
 
         // 프로필 이미지 S3 업로드 Util 메서드 사용
         String profileImageUrl = null;
+        if (profileImage != null && !profileImage.isEmpty()) {
+            try {
+                // 단일 이미지 업로드 메서드 호출
+                String imageKey = s3Util.uploadFile(profileImage, PROFILE_IMAGE_FOLDER);
+                profileImageUrl = s3Util.getImageUrl(imageKey);
+                log.info("[ 회원가입 ] 프로필 이미지 업로드 성공: {}", profileImageUrl);
+            } catch (IllegalArgumentException e) {
+                log.error("[ 회원가입 ] 프로필 이미지 업로드 실패: {}", e.getMessage());
+                throw new MemberException(MemberErrorCode.PROFILE_IMAGE_UPLOAD_FAILED);
+            }
+        } else {
+            log.info("[ 회원가입 ] 프로필 이미지 없음, 기본 이미지 사용");
+            // 기본 프로필 이미지 URL 설정
+            // profileImageUrl = "https://your-bucket.s3.region.amazonaws.com/profiles/default.png";
+        }
 
         Member member = MemberConverter.toMember(reqDTO, passwordEncoder, profileImageUrl);
         memberRepository.save(member);

--- a/src/main/java/com/project/teama_be/domain/post/entity/Post.java
+++ b/src/main/java/com/project/teama_be/domain/post/entity/Post.java
@@ -30,21 +30,26 @@ public class Post extends BaseEntity {
     private String content;
 
     @Column(name = "like_count")
+    @Builder.Default
     private Long likeCount = 0L;
 
     @Column(name = "unlike")
+    @Builder.Default
     private Long unlikeCount = 0L;
 
     @Column(name = "is_private", nullable = false)
     private Boolean isPrivate;
 
     @Column(name = "disable_comment")
+    @Builder.Default
     private Boolean disableComment = false;
 
     @Column(name = "hide_like")
+    @Builder.Default
     private Boolean hideLike = false;
 
     @Column(name = "hide_share")
+    @Builder.Default
     private Boolean hideShare = false;
 
     // update

--- a/src/main/java/com/project/teama_be/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/project/teama_be/global/security/config/SecurityConfig.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -37,6 +38,8 @@ public class SecurityConfig {
             "/api/auth/login",
             "/ws-stomp/**",  // WebSocket 관련 모든 경로 추가
             "/ws-stomp/info", // SockJS의 정보 엔드포인트 추가
+            "/oauth2/callback/kakao",
+            "/oauth2/authorization/kakao"
     };
 
     @Bean
@@ -76,6 +79,11 @@ public class SecurityConfig {
         http
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        // OAuth2 로그인 설정 추가
+        http
+                .oauth2Login(Customizer.withDefaults()
+                );
 
         // 경로별 인가
         http

--- a/src/main/java/com/project/teama_be/global/security/handler/CustomLogoutHandler.java
+++ b/src/main/java/com/project/teama_be/global/security/handler/CustomLogoutHandler.java
@@ -1,0 +1,80 @@
+package com.project.teama_be.global.security.handler;
+
+import com.project.teama_be.domain.member.service.JwtTokenService;
+import com.project.teama_be.global.security.util.JwtUtil;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+
+@Slf4j
+@RequiredArgsConstructor
+public class CustomLogoutHandler implements LogoutHandler {
+
+    private final JwtTokenService jwtTokenService;
+    private final JwtUtil jwtUtil;
+    private final String ACCESS_TOKEN_COOKIE_NAME = "access_token";
+    private final String REFRESH_TOKEN_COOKIE_NAME = "refresh_token";
+
+    @Override
+    public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        // 1. 요청에서 쿠키 추출
+        Cookie[] cookies = request.getCookies();
+        String accessToken = null;
+        String refreshToken = null;
+
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (ACCESS_TOKEN_COOKIE_NAME.equals(cookie.getName())) {
+                    accessToken = cookie.getValue();
+                } else if (REFRESH_TOKEN_COOKIE_NAME.equals(cookie.getName())) {
+                    refreshToken = cookie.getValue();
+                }
+            }
+        }
+
+        // 2. 토큰 처리
+        if (accessToken != null) {
+            // 액세스 토큰에서 loginId 추출
+            String loginId = jwtUtil.getLoginId(accessToken);
+
+            // Redis에서 저장된 리프레시 토큰 가져오기
+            if (refreshToken == null) {
+                refreshToken = jwtTokenService.getRefreshTokenByLoginId(loginId);
+            }
+
+            if (refreshToken != null) {
+                // 리프레시 토큰을 블랙리스트에 추가
+                long expiryDuration = jwtUtil.getRefreshTokenRemainingTime(refreshToken);
+                jwtTokenService.addToBlacklist(refreshToken, expiryDuration);
+            }
+
+            // 이메일과 연결된 리프레시 토큰 삭제
+            jwtTokenService.deleteRefreshTokenByLoginId(loginId);
+        }
+
+        // 3. 클라이언트에서 쿠키 삭제
+        deleteTokenCookies(response);
+    }
+
+    // 4. 응답에서 토큰 쿠키 삭제
+    private void deleteTokenCookies(HttpServletResponse response) {
+        // 액세스 토큰 쿠키 삭제
+        Cookie accessTokenCookie = new Cookie(ACCESS_TOKEN_COOKIE_NAME, null);
+        accessTokenCookie.setMaxAge(0); // 즉시 만료
+        accessTokenCookie.setPath("/");
+        accessTokenCookie.setHttpOnly(true);
+        response.addCookie(accessTokenCookie);
+
+        // 리프레시 토큰 쿠키 삭제
+        Cookie refreshTokenCookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, null);
+        refreshTokenCookie.setMaxAge(0); // 즉시 만료
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setHttpOnly(true);
+        response.addCookie(refreshTokenCookie);
+    }
+
+}

--- a/src/main/java/com/project/teama_be/global/utils/RedisUtil.java
+++ b/src/main/java/com/project/teama_be/global/utils/RedisUtil.java
@@ -24,8 +24,6 @@ public class RedisUtil {
         return redisTemplate.opsForValue().get(key);
     }
 
-    public boolean delete(String key) {
-        return Boolean.TRUE.equals(redisTemplate.delete(key));
-    }
+    public void delete(String key) { redisTemplate.delete(key); }
 
 }


### PR DESCRIPTION
# ☝️Issue Number

- #15 

##  📌 개요
https://github.com/SMUMC-8th/SPRING_A/commit/02acde7040730e25ff541defe268372675ff1fa6
- 회원가입 API 

https://github.com/SMUMC-8th/SPRING_A/commit/0e0f0e37b12dea9729e5d982a23e483700592b5a
- 로그아웃 API

https://github.com/SMUMC-8th/SPRING_A/commit/f84706eda2efe588cc46279b7b6db05d9d6446fa
- 회원가입 API에 프로필 이미지 등록 로직 추가

https://github.com/SMUMC-8th/SPRING_A/commit/59c30193ed3c6657adde8cbdc9e9f345e95aa2dd
- 카카오 로그인

https://github.com/SMUMC-8th/SPRING_A/pull/20/commits/44eda28efd085a7f2f28ed36bab2c96d0d6a3688
- 회원가입 프로필 사진 선택 안할 시 기본 프로필 이미지 설정

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
로컬 로그인과 토큰 재발급 로직은 저번에 개발 완료했습니다!
카카오 로그인 시 cookie에 access_token과 refresh_token 잘 등록되는거 확인 했습니다!