### PR TITLE
🐛 fix: 알림 FCM 저장 실패

### DIFF
--- a/src/main/java/com/project/teama_be/domain/notification/exception/code/NotiErrorCode.java
+++ b/src/main/java/com/project/teama_be/domain/notification/exception/code/NotiErrorCode.java
@@ -14,6 +14,8 @@ public enum NotiErrorCode implements BaseErrorCode {
 
     NOT_APPLY_NOTI(HttpStatus.BAD_REQUEST, "NOTI400_2", "지원하지 않는 알림 유형입니다."),
     FCM_SEND_FAIL(HttpStatus.BAD_REQUEST, "NOTI400_3", "알림 전송 실패"),
+    FCM_SEND_FAIL2(HttpStatus.BAD_REQUEST, "NOTI400_6", "알림 전송 실패222"),
+    FCM_SEND_FAIL3(HttpStatus.BAD_REQUEST, "NOTI400_7", "채팅 알림 전송 실패"),
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTI404_2", "알림을 찾을 수 없습니다."),
     NOTIFICATION_ACCESS_DENIED(HttpStatus.BAD_REQUEST, "NOTI400_4", "알림 이용 불가"),
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "NOTI400_5" ,"존재하지 않는 회원입니다." ),

--- a/src/main/java/com/project/teama_be/domain/notification/service/NotiService.java
+++ b/src/main/java/com/project/teama_be/domain/notification/service/NotiService.java
@@ -100,7 +100,7 @@ public class NotiService {
             return response;
         } catch (FirebaseMessagingException e) {
             log.error("[ FCM 전송 실패 ]", e);
-            throw new NotiException(NotiErrorCode.FCM_SEND_FAIL);
+            throw new NotiException(NotiErrorCode.FCM_SEND_FAIL2);
         }
     }
 
@@ -186,7 +186,7 @@ public class NotiService {
             return FirebaseMessaging.getInstance().sendAll(messages);
         } catch (FirebaseMessagingException e) {
             log.error("[ FCM 멀티캐스트 전송 실패 ]", e);
-            throw new NotiException(NotiErrorCode.FCM_SEND_FAIL);
+            throw new NotiException(NotiErrorCode.FCM_SEND_FAIL3);
         }
     }
 

--- a/src/main/java/com/project/teama_be/domain/post/service/command/PostCommandService.java
+++ b/src/main/java/com/project/teama_be/domain/post/service/command/PostCommandService.java
@@ -158,7 +158,7 @@ public class PostCommandService {
         log.info("[ 게시글 좋아요 ] reaction:{}", reaction);
 
         try {   //member:로그인된 사용자, post에서 member:알림을 받는 사람
-            notiService.sendMessage(member, post.getMember(), NotiType.LIKE);
+            notiService.sendMessage(member, post.getMember(), post, NotiType.LIKE);
         } catch (FirebaseMessagingException e) {
             throw new NotiException(NotiErrorCode.FCM_SEND_FAIL);
         }


### PR DESCRIPTION
# ☝️Issue Number

- #38 

##  📌 개요

- {
  "isSuccess": false,
  "code": "NOTI400_3",
  "message": "알림 전송 실패",
  "result": null
}

## 🔁 변경 사항
709adc1ec715b9a63a9ec741310f62ed9d7eddb9

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점