### PR TITLE
🐛fix: FCM Token 저장 시 토큰 값만 저장되게 변경

### DIFF
--- a/src/main/java/com/project/teama_be/domain/notification/controller/NotiController.java
+++ b/src/main/java/com/project/teama_be/domain/notification/controller/NotiController.java
@@ -38,9 +38,9 @@ public class NotiController {
     //fcm토큰 저장
     @PostMapping("/token")
     @Operation(summary = "FCM API by 신윤진", description = "FCM 토큰을 받아와 저장합니다.")
-    public CustomResponse<NotiResDTO> saveToken(@CurrentUser AuthUser user, @RequestBody NotiReqDTO.FcmToken reqDTO) {
-        notiService.saveFcmToken(user.getUserId(), reqDTO);
-        return CustomResponse.onSuccess(null);
+    public CustomResponse<NotiResDTO.SaveFcmToken> saveToken(@CurrentUser AuthUser user, @RequestBody NotiReqDTO.FcmToken reqDTO) {
+        NotiResDTO.SaveFcmToken resDTO = notiService.saveFcmToken(user.getUserId(), reqDTO);
+        return CustomResponse.onSuccess(resDTO);
     }
 
 //    //fcm 푸시 알림 전송

--- a/src/main/java/com/project/teama_be/domain/notification/converter/NotiConverter.java
+++ b/src/main/java/com/project/teama_be/domain/notification/converter/NotiConverter.java
@@ -6,12 +6,14 @@ import com.project.teama_be.domain.notification.entity.Noti;
 import com.project.teama_be.domain.notification.enums.NotiStatus;
 import com.project.teama_be.domain.notification.enums.NotiType;
 import com.project.teama_be.domain.post.entity.Post;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.springframework.stereotype.Component;
 
-@Component
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class NotiConverter {
 
-    public Noti toNoty(Member member, Post post, NotiType type, String title, String body) {
+    public static Noti toNoty(Member member, Post post, NotiType type, String title, String body) {
         return Noti.builder()
                 .member(member)
                 .post(post)
@@ -23,7 +25,7 @@ public class NotiConverter {
                 .build();
     }
 
-    public Noti toChatNoti(Member member, NotiType type, String title, String body) {
+    public static Noti toChatNoti(Member member, NotiType type, String title, String body) {
         return Noti.builder()
                 .member(member)
                 .type(type)
@@ -34,7 +36,7 @@ public class NotiConverter {
                 .build();
     }
 
-    public NotiResDTO.NotificationSendResDTO toSendResDTO(Noti noti, String fcmMessageId) {
+    public static NotiResDTO.NotificationSendResDTO toSendResDTO(Noti noti, String fcmMessageId) {
         return new NotiResDTO.NotificationSendResDTO(
                 noti.getTitle(),
                 noti.getBody(),
@@ -43,7 +45,7 @@ public class NotiConverter {
         );
     }
 
-    public NotiResDTO.NotificationListResDTO toNotiResDto(Noti noti) {
+    public static NotiResDTO.NotificationListResDTO toNotiResDto(Noti noti) {
         return new NotiResDTO.NotificationListResDTO(
                 noti.getId(),
                 noti.getTitle(),
@@ -51,5 +53,12 @@ public class NotiConverter {
                 noti.getIsRead(),
                 noti.getCreatedAt()
         );
+    }
+
+    public static NotiResDTO.SaveFcmToken toSaveFcmTokenResDTO(Long memberId, String fcmToken) {
+        return NotiResDTO.SaveFcmToken.builder()
+                .memberId(memberId)
+                .fcmToken(fcmToken)
+                .build();
     }
 }

--- a/src/main/java/com/project/teama_be/domain/notification/dto/NotiResDTO.java
+++ b/src/main/java/com/project/teama_be/domain/notification/dto/NotiResDTO.java
@@ -1,9 +1,18 @@
 package com.project.teama_be.domain.notification.dto;
 
+import lombok.Builder;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
 public class NotiResDTO {
+
+    @Builder
+    public record SaveFcmToken(
+            Long memberId,
+            String fcmToken
+    ) {
+    }
 
     public record FcmMessage(String title, String body) {}
 

--- a/src/main/java/com/project/teama_be/global/utils/RedisUtil.java
+++ b/src/main/java/com/project/teama_be/global/utils/RedisUtil.java
@@ -18,11 +18,11 @@ public class RedisUtil {
     }
 
     public void saveFcmToken(String key, NotiReqDTO.FcmToken token){
-        redisTemplate.opsForValue().set(key, token);
+        redisTemplate.opsForValue().set(key, token.fcmToken());
     }
 
-    public NotiReqDTO.FcmToken getFcmToken(String key) {
-        return (NotiReqDTO.FcmToken) redisTemplate.opsForValue().get(key);
+    public String getFcmToken(String key) {
+        return (String) redisTemplate.opsForValue().get(key);
     }
 
     public boolean hasKey(String key) {


### PR DESCRIPTION
# ☝️Issue Number

- #40 

##  📌 개요
https://github.com/SMUMC-8th/SPRING_A/commit/77db54f4cb040e2a588f72729a40dc381d17106a
- 🐛fix: FCM Token 저장 시 토큰 값만 저장되게 변경

https://github.com/SMUMC-8th/SPRING_A/commit/c7a83decf01869d558687db7ac10059201fc1861
- ♻️refactor: FCM 토큰 저장 API 응답 형식 변경


## 🔁 변경 사항

### 🐛fix: FCM Token 저장 시 토큰 값만 저장되게 변경
- 기존
<img width="809" alt="image" src="https://github.com/user-attachments/assets/9ca84cf4-8bf3-4052-a599-e903bb6c7816" />

- 변경 후
<img width="236" alt="image" src="https://github.com/user-attachments/assets/055725c5-0eca-49a3-a104-dc8a4f1c2b70" />


### ♻️refactor: FCM 토큰 저장 API 응답 형식 변경
- 기존
<img width="1418" alt="image" src="https://github.com/user-attachments/assets/b42f3d5f-fa41-4083-8e01-6339a988a679" />

- 변경 후
<img width="1413" alt="image" src="https://github.com/user-attachments/assets/68666f22-705d-4141-a10e-ba2ede8ecce4" />


## 📸 스크린샷

## 👀 기타 더 이야기해볼 점