### PR TITLE
✨ feat: Post, Comment 사용자 차단 기능 구현

### DIFF
--- a/src/main/java/com/project/teama_be/domain/member/repository/NotRecommendedQueryDsl.java
+++ b/src/main/java/com/project/teama_be/domain/member/repository/NotRecommendedQueryDsl.java
@@ -1,0 +1,10 @@
+package com.project.teama_be.domain.member.repository;
+
+import java.util.List;
+
+public interface NotRecommendedQueryDsl {
+    // 차단한 유저 ID 조회
+    List<Long> findBlockingUserList(
+            Long memberId
+    );
+}

--- a/src/main/java/com/project/teama_be/domain/member/repository/NotRecommendedQueryDsl.java
+++ b/src/main/java/com/project/teama_be/domain/member/repository/NotRecommendedQueryDsl.java
@@ -7,4 +7,9 @@ public interface NotRecommendedQueryDsl {
     List<Long> findBlockingUserList(
             Long memberId
     );
+
+    // 날 차단한 유저 리스트 조회
+    List<Long> findBlockerList(
+            Long memberId
+    );
 }

--- a/src/main/java/com/project/teama_be/domain/member/repository/NotRecommendedQueryDslImpl.java
+++ b/src/main/java/com/project/teama_be/domain/member/repository/NotRecommendedQueryDslImpl.java
@@ -13,7 +13,7 @@ public class NotRecommendedQueryDslImpl implements NotRecommendedQueryDsl {
 
     private final JPAQueryFactory jpaQueryFactory;
 
-    // 차단한 유저 ID 조회
+    // 내가 차단한 유저 리스트 조회
     @Override
     public List<Long> findBlockingUserList(
             Long memberId
@@ -24,6 +24,20 @@ public class NotRecommendedQueryDslImpl implements NotRecommendedQueryDsl {
                 .select(notRecommended.targetMemberId)
                 .from(notRecommended)
                 .where(notRecommended.member.id.eq(memberId))
+                .fetch();
+    }
+
+    // 날 차단한 유저 리스트 조회
+    @Override
+    public List<Long> findBlockerList(
+            Long memberId
+    ){
+        QNotRecommended notRecommended = QNotRecommended.notRecommended;
+
+        return jpaQueryFactory
+                .select(notRecommended.member.id)
+                .from(notRecommended)
+                .where(notRecommended.targetMemberId.eq(memberId))
                 .fetch();
     }
 }

--- a/src/main/java/com/project/teama_be/domain/member/repository/NotRecommendedQueryDslImpl.java
+++ b/src/main/java/com/project/teama_be/domain/member/repository/NotRecommendedQueryDslImpl.java
@@ -1,0 +1,29 @@
+package com.project.teama_be.domain.member.repository;
+
+import com.project.teama_be.domain.member.entity.QNotRecommended;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class NotRecommendedQueryDslImpl implements NotRecommendedQueryDsl {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    // 차단한 유저 ID 조회
+    @Override
+    public List<Long> findBlockingUserList(
+            Long memberId
+    ){
+        QNotRecommended notRecommended = QNotRecommended.notRecommended;
+
+        return jpaQueryFactory
+                .select(notRecommended.targetMemberId)
+                .from(notRecommended)
+                .where(notRecommended.member.id.eq(memberId))
+                .fetch();
+    }
+}

--- a/src/main/java/com/project/teama_be/domain/member/repository/NotRecommendedRepository.java
+++ b/src/main/java/com/project/teama_be/domain/member/repository/NotRecommendedRepository.java
@@ -3,5 +3,5 @@ package com.project.teama_be.domain.member.repository;
 import com.project.teama_be.domain.member.entity.NotRecommended;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface NotRecommendedRepository extends JpaRepository<NotRecommended, Long> {
+public interface NotRecommendedRepository extends JpaRepository<NotRecommended, Long>, NotRecommendedQueryDsl {
 }

--- a/src/main/java/com/project/teama_be/domain/post/controller/CommentController.java
+++ b/src/main/java/com/project/teama_be/domain/post/controller/CommentController.java
@@ -37,13 +37,15 @@ public class CommentController {
     public CustomResponse<CommentResDTO.PageableComment<CommentResDTO.Comment>> getComments(
             @PathVariable @NotNull(message = "게시글ID는 필수 입력입니다.")
             Long postId,
+            @CurrentUser
+            AuthUser authUser,
             @RequestParam(defaultValue = "-1") @Min(value = -1, message = "커서는 -1 이상이어야 합니다.")
             String cursor,
             @RequestParam(defaultValue = "1") @Min(value = 1, message = "댓글은 최소 하나 이상 조회해야 합니다.")
             int size
     ) {
         log.info("[ 댓글 목록 조회 ] postID:{}, cursor:{}, size:{}", postId, cursor, size);
-        return CustomResponse.onSuccess(commentQueryService.findComments(postId, cursor, size));
+        return CustomResponse.onSuccess(commentQueryService.findComments(authUser, postId, cursor, size));
     }
 
     // 대댓글 목록 조회 ✅
@@ -56,13 +58,15 @@ public class CommentController {
     public CustomResponse<CommentResDTO.PageableComment<CommentResDTO.Reply>> getReplies(
             @PathVariable @NotNull(message = "댓글ID는 필수 입력입니다.")
             Long commentId,
+            @CurrentUser
+            AuthUser authUser,
             @RequestParam(defaultValue = "-1") @Min(value = -1, message = "커서는 -1 이상이어야 합니다.")
             String cursor,
             @RequestParam(defaultValue = "1") @Min(value = 1, message = "대댓글은 최소 하나 이상 조회해야 합니다.")
             int size
     ) {
         log.info("[ 대댓글 목록 조회 ] commentID:{}, cursor:{}, size:{}", commentId, cursor, size);
-        return CustomResponse.onSuccess(commentQueryService.findReplyComments(commentId, cursor, size));
+        return CustomResponse.onSuccess(commentQueryService.findReplyComments(authUser, commentId, cursor, size));
     }
 
     // 내가 작성한 댓글 조회 ✅
@@ -100,13 +104,7 @@ public class CommentController {
             CommentReqDTO.Commenting content
     ) {
         log.info("[ 댓글 작성 ] postID:{}, user:{}, content:{}", postId, user.getLoginId(), content);
-        return CustomResponse.onSuccess(
-                commentCommandService.createComment(
-                        postId,
-                        user,
-                        content.content()
-                )
-        );
+        return CustomResponse.onSuccess(commentCommandService.createComment(postId, user, content.content()));
     }
 
     // 대댓글 작성✅

--- a/src/main/java/com/project/teama_be/domain/post/controller/PostController.java
+++ b/src/main/java/com/project/teama_be/domain/post/controller/PostController.java
@@ -44,11 +44,13 @@ public class PostController {
     )
     public CustomResponse<PostResDTO.HomePost> getPostsByPlaceName(
             @RequestParam @Valid @NotEmpty(message = "쿼리는 필수 입력값입니다.")
-            List<PostReqDTO.Query> query
+            List<String> query,
+            @CurrentUser
+            AuthUser user
     ) {
 
         log.info("[ 각 가게 최신 게시글 조회 ] queryCnt:{}", query.size());
-        return CustomResponse.onSuccess(postQueryService.getPost(query));
+        return CustomResponse.onSuccess(postQueryService.getPost(user, query));
     }
 
     // 키워드 검색 ✅
@@ -71,10 +73,12 @@ public class PostController {
             String cursor,
             @RequestParam(defaultValue = "1") @NotNull(message = "조회할 데이터 사이즈를 요청해야 합니다.")
             @Min(value = 1, message = "게시글은 최소 하나 이상 조회해야 합니다.")
-            int size
+            int size,
+            @CurrentUser
+            AuthUser user
     ) {
         log.info("[ 키워드 검색 ] query:{}, type:{}, cursor:{}, size:{}", query, type, cursor, size);
-        return CustomResponse.onSuccess(postQueryService.getPostsByKeyword(query, type, cursor, size));
+        return CustomResponse.onSuccess(postQueryService.getPostsByKeyword(query, type, cursor, size, user));
     }
 
     // 가게 게시글 모두 조회 ✅
@@ -93,10 +97,12 @@ public class PostController {
             String cursor,
             @RequestParam(defaultValue = "1") @NotNull(message = "조회할 데이터 사이즈를 요청해야 합니다.")
             @Min(value = 1, message = "게시글은 최소 하나 이상 조회해야 합니다.")
-            int size
+            int size,
+            @CurrentUser
+            AuthUser user
     ) {
         log.info("[ 가게 게시글 모두 조회 ] placeId:{}, cursor:{}, size:{}", placeId, cursor, size);
-        return CustomResponse.onSuccess(postQueryService.getPostsByPlaceId(placeId, cursor, size));
+        return CustomResponse.onSuccess(postQueryService.getPostsByPlaceId(placeId, cursor, size, user));
     }
 
     // 내가 작성한 게시글 조회 (마이페이지) ✅

--- a/src/main/java/com/project/teama_be/domain/post/dto/request/PostReqDTO.java
+++ b/src/main/java/com/project/teama_be/domain/post/dto/request/PostReqDTO.java
@@ -1,6 +1,5 @@
 package com.project.teama_be.domain.post.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
@@ -39,11 +38,5 @@ public class PostReqDTO {
             @Size(max = 5, message = "태그는 최대 5개까지 입력할 수 있습니다.")
             List<String> tags,
             Long placeId
-    ) {}
-
-    // 각 가게 최신 게시글 조회
-    public record Query(
-            @NotBlank(message = "쿼리는 필수 입력값입니다.")
-            String query
     ) {}
 }

--- a/src/main/java/com/project/teama_be/domain/post/exception/code/CommentErrorCode.java
+++ b/src/main/java/com/project/teama_be/domain/post/exception/code/CommentErrorCode.java
@@ -29,7 +29,10 @@ public enum CommentErrorCode implements BaseErrorCode {
             "댓글 작성자만 접근할 수 있습니다."),
     NOT_BLANK(HttpStatus.BAD_REQUEST,
             "COMMENT400_0",
-            "댓글 내용이 비어있습니다."),;
+            "댓글 내용이 비어있습니다."),
+    BLOCKING(HttpStatus.FORBIDDEN,
+            "USER401_0",
+            "접근이 거부되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/project/teama_be/domain/post/repository/PostQueryDslImpl.java
+++ b/src/main/java/com/project/teama_be/domain/post/repository/PostQueryDslImpl.java
@@ -305,7 +305,7 @@ public class PostQueryDslImpl implements PostQueryDsl{
         return result;
     }
 
-    // FullPost 부가 속성들 조회 ✅
+    // FullPost 부가 속성들 조회: 양방향 매핑으로 인해 수정 필요
     private List<PostResDTO.FullPost> findFullPostAttribute(
             List<Post> postList,
             PostResDTO.Cursor cursor
@@ -342,16 +342,18 @@ public class PostQueryDslImpl implements PostQueryDsl{
                                 GroupBy.list(postTag.tag.tagName)
                         )
                 );
-        // 게시글 댓글 조회
+
+        // 게시글 댓글 개수 조회
         Map<Long, Long> commentList = jpaQueryFactory
                 .from(comment)
-                .where(comment.post.id.in(postIdList))
+                .where(comment.post.id.in(postIdList).and(comment.parentId.eq(0L)))
                 .groupBy(comment.post.id)
                 .transform(
                         GroupBy.groupBy(comment.post.id).as(
                                 comment.count()
                         )
                 );
+
         // 합치기
         List<PostResDTO.FullPost> result = postList.stream()
                 .map(eachPost ->

--- a/src/main/java/com/project/teama_be/domain/post/repository/PostQueryDslImpl.java
+++ b/src/main/java/com/project/teama_be/domain/post/repository/PostQueryDslImpl.java
@@ -264,7 +264,7 @@ public class PostQueryDslImpl implements PostQueryDsl{
         return PostConverter.toCursor(nextCursor.toString(), hasNext, pageSize);
     }
 
-    // SimplePost 부가 속성들 조회✅
+    // SimplePost 부가 속성들 조회: 여러번 쿼리문 날리는 방식 -> 서브쿼리로 묶는 방식 으로 변경해야 함
     private List<PostResDTO.SimplePost> findSimplePostAttribute(
             List<Post> postList,
             PostResDTO.Cursor cursor
@@ -305,7 +305,7 @@ public class PostQueryDslImpl implements PostQueryDsl{
         return result;
     }
 
-    // FullPost 부가 속성들 조회: 양방향 매핑으로 인해 수정 필요
+    // FullPost 부가 속성들 조회: 여러번 쿼리문 날리는 방식 -> 서브쿼리로 묶는 방식 으로 변경해야 함
     private List<PostResDTO.FullPost> findFullPostAttribute(
             List<Post> postList,
             PostResDTO.Cursor cursor

--- a/src/main/java/com/project/teama_be/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/project/teama_be/domain/post/repository/PostRepository.java
@@ -3,6 +3,9 @@ package com.project.teama_be.domain.post.repository;
 import com.project.teama_be.domain.post.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PostRepository extends JpaRepository<Post, Long>, PostQueryDsl {
 
+    Optional<Post> findPostById(Long postId);
 }

--- a/src/main/java/com/project/teama_be/domain/post/service/command/CommentCommandService.java
+++ b/src/main/java/com/project/teama_be/domain/post/service/command/CommentCommandService.java
@@ -4,6 +4,7 @@ package com.project.teama_be.domain.post.service.command;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.project.teama_be.domain.member.entity.Member;
 import com.project.teama_be.domain.member.repository.MemberRepository;
+import com.project.teama_be.domain.member.repository.NotRecommendedRepository;
 import com.project.teama_be.domain.notification.enums.NotiType;
 import com.project.teama_be.domain.notification.exception.NotiException;
 import com.project.teama_be.domain.notification.exception.code.NotiErrorCode;
@@ -29,6 +30,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -39,6 +41,7 @@ public class CommentCommandService {
     private final CommentReactionRepository commentReactionRepository;
     private final MemberRepository memberRepository;
     private final PostRepository postRepository;
+    private final NotRecommendedRepository notRecommendedRepository;
     private final NotiService notiService;
 
     // 댓글 작성 ✅
@@ -60,6 +63,10 @@ public class CommentCommandService {
         if (content.isBlank()) {
             throw new CommentException(CommentErrorCode.NOT_BLANK);
         }
+
+        // 차단 여부 확인
+        isBlocking(user, post.getMember().getId());
+
         log.info("[ 댓글 작성 ] postID:{}, member:{}, content:{}", post.getId(), member.getLoginId(), content);
         Comment comment = commentRepository.save(
                 CommentConverter.toComment(post, member, content)
@@ -84,18 +91,24 @@ public class CommentCommandService {
         // 유저 정보
         Member member = getMember(user);
 
+        // 댓글 정보
+        Comment comment = commentRepository.findById(commentId).orElseThrow(()->
+                new CommentException(CommentErrorCode.NOT_FOUND));
+
         // 게시글 정보
-        Post post = commentRepository.findById(commentId).orElseThrow(()->
-                new CommentException(CommentErrorCode.NOT_FOUND))
-                .getPost();
+        Post post = comment.getPost();
 
         // 대댓글 저장
         if (content.isBlank()) {
             throw new CommentException(CommentErrorCode.NOT_BLANK);
         }
+
+        // 차단 여부 확인
+        isBlocking(user, comment.getMember().getId());
+
         log.info("[ 대댓글 작성 ] postID:{}, member:{}, content:{}, commentID:{}",
                 post.getId(), member.getLoginId(), content, commentId);
-        Comment comment = commentRepository.save(
+        Comment result = commentRepository.save(
                 CommentConverter.toReply(post, member, content, commentId)
         );
 
@@ -105,7 +118,7 @@ public class CommentCommandService {
             throw new NotiException(NotiErrorCode.FCM_SEND_FAIL);
         }
 
-        return CommentConverter.toCommentUpload(comment);
+        return CommentConverter.toCommentUpload(result);
     }
 
     // 댓글 좋아요 ✅
@@ -120,6 +133,9 @@ public class CommentCommandService {
         // 댓글 좋아요
         Comment comment = commentRepository.findById(commentId).orElseThrow(()->
                 new CommentException(CommentErrorCode.NOT_FOUND));
+
+        // 차단 여부 확인
+        isBlocking(user, comment.getMember().getId());
 
         // 좋아요 여부 조회
         CommentReaction commentReaction= commentReactionRepository
@@ -203,5 +219,13 @@ public class CommentCommandService {
 
         return memberRepository.findByLoginId(user.getLoginId()).orElseThrow(() ->
                 new UsernameNotFoundException("로그인된 유저를 찾을 수 없습니다."));
+    }
+
+    // 차단당한 유저인지 확인
+    private void isBlocking(AuthUser targetUser, Long userId) {
+        List<Long> result = notRecommendedRepository.findBlockingUserList(userId);
+        if (result.contains(targetUser.getUserId())) {
+            throw new CommentException(CommentErrorCode.BLOCKING);
+        }
     }
 }

--- a/src/main/java/com/project/teama_be/domain/post/service/command/CommentCommandService.java
+++ b/src/main/java/com/project/teama_be/domain/post/service/command/CommentCommandService.java
@@ -72,11 +72,12 @@ public class CommentCommandService {
                 CommentConverter.toComment(post, member, content)
         );
 
-        try {   //member:로그인된 사용자, post에서 member:알림을 받는 사람
-            notiService.sendMessage(member, post.getMember(), post, NotiType.COMMENT);
-        } catch (FirebaseMessagingException e) {
-            throw new NotiException(NotiErrorCode.FCM_SEND_FAIL);
-        }
+        // 알람 기능: 주석처리
+//        try {   //member:로그인된 사용자, post에서 member:알림을 받는 사람
+//            notiService.sendMessage(member, post.getMember(), post, NotiType.COMMENT);
+//        } catch (FirebaseMessagingException e) {
+//            throw new NotiException(NotiErrorCode.FCM_SEND_FAIL);
+//        }
 
         return CommentConverter.toCommentUpload(comment);
     }
@@ -112,11 +113,12 @@ public class CommentCommandService {
                 CommentConverter.toReply(post, member, content, commentId)
         );
 
-        try {   //member:로그인된 사용자, post에서 member:알림을 받는 사람
-            notiService.sendMessage(member, post.getMember(), post, NotiType.COMMENT_COMMENT);
-        } catch (FirebaseMessagingException e) {
-            throw new NotiException(NotiErrorCode.FCM_SEND_FAIL);
-        }
+        // 알람 기능: 주석처리
+//        try {   //member:로그인된 사용자, post에서 member:알림을 받는 사람
+//            notiService.sendMessage(member, post.getMember(), post, NotiType.COMMENT_COMMENT);
+//        } catch (FirebaseMessagingException e) {
+//            throw new NotiException(NotiErrorCode.FCM_SEND_FAIL);
+//        }
 
         return CommentConverter.toCommentUpload(result);
     }
@@ -168,11 +170,12 @@ public class CommentCommandService {
             // 알람 보낼 post
             Post post = comment.getPost();
 
-            try {
-                notiService.sendMessage(member, comment.getMember(), post, NotiType.COMMENT_LIKE);
-            } catch (FirebaseMessagingException e) {
-                throw new NotiException(NotiErrorCode.FCM_SEND_FAIL);
-            }
+            // 알람 기능: 주석처리
+//            try {
+//                notiService.sendMessage(member, comment.getMember(), post, NotiType.COMMENT_LIKE);
+//            } catch (FirebaseMessagingException e) {
+//                throw new NotiException(NotiErrorCode.FCM_SEND_FAIL);
+//            }
         }
 
         return CommentConverter.toCommentLike(commentReaction);

--- a/src/main/java/com/project/teama_be/domain/post/service/command/PostCommandService.java
+++ b/src/main/java/com/project/teama_be/domain/post/service/command/PostCommandService.java
@@ -163,11 +163,13 @@ public class PostCommandService {
         if (reaction.getReactionType().equals(ReactionType.LIKE)) {
 
             post.updateLikeCount(post.getLikeCount() + 1);
-            try {
-                notiService.sendMessage(member, post.getMember(), post, NotiType.LIKE);
-            } catch (FirebaseMessagingException e) {
-                throw new NotiException(NotiErrorCode.FCM_SEND_FAIL);
-            }
+
+            // 알람 기능: 주석처리
+//            try {
+//                notiService.sendMessage(member, post.getMember(), post, NotiType.LIKE);
+//            } catch (FirebaseMessagingException e) {
+//                throw new NotiException(NotiErrorCode.FCM_SEND_FAIL);
+//            }
         }
 
         log.info("[ 게시글 좋아요 ] reactionID:{}", reaction.getId());

--- a/src/main/java/com/project/teama_be/domain/post/service/query/CommentQueryService.java
+++ b/src/main/java/com/project/teama_be/domain/post/service/query/CommentQueryService.java
@@ -1,11 +1,17 @@
 package com.project.teama_be.domain.post.service.query;
 
 import com.project.teama_be.domain.member.entity.QNotRecommended;
+import com.project.teama_be.domain.member.repository.NotRecommendedRepository;
 import com.project.teama_be.domain.post.dto.response.CommentResDTO;
+import com.project.teama_be.domain.post.entity.Comment;
+import com.project.teama_be.domain.post.entity.Post;
 import com.project.teama_be.domain.post.entity.QComment;
 import com.project.teama_be.domain.post.exception.CommentException;
+import com.project.teama_be.domain.post.exception.PostException;
 import com.project.teama_be.domain.post.exception.code.CommentErrorCode;
+import com.project.teama_be.domain.post.exception.code.PostErrorCode;
 import com.project.teama_be.domain.post.repository.CommentRepository;
+import com.project.teama_be.domain.post.repository.PostRepository;
 import com.project.teama_be.global.security.userdetails.AuthUser;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.JPAExpressions;
@@ -13,12 +19,16 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class CommentQueryService {
 
     private final CommentRepository commentRepository;
+    private final NotRecommendedRepository notRecommendedRepository;
+    private final PostRepository postRepository;
 
     // 댓글 목록 조회 ✅
     public CommentResDTO.PageableComment<CommentResDTO.Comment> findComments(
@@ -31,16 +41,28 @@ public class CommentQueryService {
         QComment comment = QComment.comment;
         QNotRecommended notRecommended = QNotRecommended.notRecommended;
 
+        // 게시글 주인이 날 차단했는지 확인: 게시글 주인과 차단한 상대가 다른 경우
+        Post origin = postRepository.findPostById(postId).orElseThrow(()->
+                new PostException(PostErrorCode.NOT_FOUND));
+        isBlockedUser(user.getUserId(), origin.getMember().getId());
+
         BooleanBuilder builder = new BooleanBuilder();
         builder.and(comment.post.id.eq(postId))
                 // 대댓글 조회 방지
                 .and(comment.parentId.eq(0L))
-                // 차단한 사용자의 댓글 제외
+                // 내가 차단한 사용자의 댓글 제외
                 .and(comment.member.id.notIn(
                         JPAExpressions.select(notRecommended.targetMemberId)
                                 .from(notRecommended)
                                 .where(notRecommended.member.id.in(user.getUserId()))
-                ));
+                ))
+                // 상대방이 차단한 경우, 상대방 댓글 제외
+                .and(comment.member.id.notIn(
+                        JPAExpressions.select(notRecommended.member.id)
+                                .from(notRecommended)
+                                .where(notRecommended.targetMemberId.in(user.getUserId()))
+                ))
+        ;
 
         if (!cursor.equals("-1")) {
             try {
@@ -65,6 +87,11 @@ public class CommentQueryService {
         QComment comment = QComment.comment;
         QNotRecommended notRecommended = QNotRecommended.notRecommended;
 
+        // 댓글 주인이 날 차단했는지 확인
+        Comment origin = commentRepository.findById(commentId).orElseThrow(() ->
+                new CommentException(CommentErrorCode.NOT_FOUND));
+        isBlockedUser(user.getUserId(), origin.getMember().getId());
+
         BooleanBuilder builder = new BooleanBuilder();
         builder.and(comment.parentId.eq(commentId))
                 // 차단한 사용자의 댓글 제외
@@ -72,6 +99,12 @@ public class CommentQueryService {
                 JPAExpressions.select(notRecommended.targetMemberId)
                         .from(notRecommended)
                         .where(notRecommended.member.id.in(user.getUserId()))
+                ))
+                // 상대방이 차단한 경우, 상대방 댓글 제외
+                .and(comment.member.id.notIn(
+                        JPAExpressions.select(notRecommended.member.id)
+                                .from(notRecommended)
+                                .where(notRecommended.targetMemberId.in(user.getUserId()))
                 ));
 
         if (!cursor.equals("-1")) {
@@ -111,5 +144,13 @@ public class CommentQueryService {
         log.info("[ 내가 작성한 댓글 조회 ] subQuery:{}", builder);
         return commentRepository.getMyComments(builder, size);
 
+    }
+
+    // 사용자가 날 차단했는지 확인
+    private void isBlockedUser(Long userId, Long targetUserId) {
+        List<Long> blackList = notRecommendedRepository.findBlockingUserList(targetUserId);
+        if (blackList.contains(userId)) {
+            throw new CommentException(CommentErrorCode.BLOCKING);
+        }
     }
 }


### PR DESCRIPTION
# ☝️Issue Number

- #52 

##  📌 개요

- 사용자가 차단했을 경우, 차단한 사용자의 게시글, 댓글, 대댓글 제공 X
- 차단당한 사용자 또한 차단한 사용자의 게시글, 댓글, 대댓글 제공 X
- 차단당한 사용자가 차단한 사용자의 게시글에 댓글, 대댓글 작성 X

### 🐛 추가 수정
- 각 가게 최신 게시글 조회 API, Swagger에서 List\<DTO\>가 테스트하기 불편함. List\<DTO\> -> List\<String\>으로 변경

## 🔁 변경 사항

- Post 차단기능 구현 : f7c1a85ecdadb1bf814456a6303c39b6caaf6135
- Comment 차단기능 구현 : 21d9a947b6048192e9616619657db8daae561db0

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점